### PR TITLE
ZeraJsonParamsState: Add a constructor with parameter json structure

### DIFF
--- a/zera-json-params/main.cpp
+++ b/zera-json-params/main.cpp
@@ -41,8 +41,7 @@ int main(int argc, char *argv[])
 
             if(errListStructure.isEmpty()) { // valid structure is mandatory for state
                 QJsonObject jsonStateDataLoaded;
-                ZeraJsonParamsState jsonParamState;
-                jsonParamState.setStructure(jsonParamStructure.getJson());
+                ZeraJsonParamsState jsonParamState(jsonParamStructure.getJson());
                 if(!jsonStateInputFileName.isEmpty()) {
                     QFile jsonStateFile(jsonStateInputFileName);
                     ok = jsonStateFile.open(QIODevice::Unbuffered | QIODevice::ReadOnly);

--- a/zera-json-params/src/jsonstatefilepersistence.cpp
+++ b/zera-json-params/src/jsonstatefilepersistence.cpp
@@ -24,8 +24,7 @@ QJsonObject JsonStateFilePersistence::getJsonParamStructure() const
 
 bool JsonStateFilePersistence::checkStateValidity(const QJsonObject &stateObject)
 {
-    ZeraJsonParamsState jsonParamsState;
-    jsonParamsState.setStructure(m_jsonParamStructure);
+    ZeraJsonParamsState jsonParamsState(m_jsonParamStructure);
     ZeraJsonParamsState::ErrList errList = jsonParamsState.validateJsonState(stateObject);
     return errList.isEmpty();
 }
@@ -33,9 +32,8 @@ bool JsonStateFilePersistence::checkStateValidity(const QJsonObject &stateObject
 QJsonObject JsonStateFilePersistence::loadState()
 {
     QJsonObject paramState;
-    ZeraJsonParamsState jsonParamsState;
+    ZeraJsonParamsState jsonParamsState(m_jsonParamStructure);
     try {
-        jsonParamsState.setStructure(m_jsonParamStructure);
         QJsonObject stateObject = cJsonFileLoader::loadJsonFile(m_stateFilePath);
         bool isValidState = checkStateValidity(stateObject);
         if(!isValidState) {

--- a/zera-json-params/src/zera-json-params-state.cpp
+++ b/zera-json-params/src/zera-json-params-state.cpp
@@ -6,7 +6,11 @@
 
 ZeraJsonParamsState::ZeraJsonParamsState()
 {
+}
 
+ZeraJsonParamsState::ZeraJsonParamsState(const QJsonObject jsonStructure)
+{
+    m_jsonStructure = jsonStructure;
 }
 
 void ZeraJsonParamsState::setStructure(const QJsonObject jsonStructure)

--- a/zera-json-params/src/zera-json-params-state.h
+++ b/zera-json-params/src/zera-json-params-state.h
@@ -8,6 +8,7 @@ class ZeraJsonParamsState
 {
 public:
     ZeraJsonParamsState();
+    ZeraJsonParamsState(const QJsonObject jsonStructure);
 
     enum errorTypes {
         ERR_INVALID_STRUCTURE = 0,

--- a/zera-json-params/unittest/unittest-json-state-file-persistence.cpp
+++ b/zera-json-params/unittest/unittest-json-state-file-persistence.cpp
@@ -31,9 +31,8 @@ TEST(TEST_JSON_PERSISTENCE, SAVE_VALID_STATE) {
     QTemporaryFile file;
     file.open();
 
-    ZeraJsonParamsState defaultStateGenerator;
     QJsonObject stateStruct = cJsonFileLoader::loadJsonFile(":/json-test-files/TEST_PERSISTENCE_STRUCTURE.json");
-    defaultStateGenerator.setStructure(stateStruct);
+    ZeraJsonParamsState defaultStateGenerator(stateStruct);
 
     QJsonObject correctStateDefault = defaultStateGenerator.getDefaultJsonState();
 
@@ -57,8 +56,7 @@ TEST(TEST_JSON_PERSISTENCE, LOAD_INVALID_FILE) {
     QJsonObject stateStruct = cJsonFileLoader::loadJsonFile(":/json-test-files/TEST_PERSISTENCE_STRUCTURE.json");
     persistentStateHelper.setJsonParamStructure(stateStruct);
 
-    ZeraJsonParamsState defaultStateGenerator;
-    defaultStateGenerator.setStructure(stateStruct);
+    ZeraJsonParamsState defaultStateGenerator(stateStruct);
 
     QJsonObject jsonState = persistentStateHelper.loadState();
 
@@ -75,8 +73,7 @@ TEST(TEST_JSON_PERSISTENCE, LOAD_NOTEXIST_FILE) {
     QJsonObject state = cJsonFileLoader::loadJsonFile(file.fileName());
     persistentStateHelper.setJsonParamStructure(stateStruct);
 
-    ZeraJsonParamsState defaultStateGenerator;
-    defaultStateGenerator.setStructure(stateStruct);
+    ZeraJsonParamsState defaultStateGenerator(stateStruct);
 
     QJsonObject correctStateDefault=defaultStateGenerator.getDefaultJsonState();
 

--- a/zera-json-params/unittest/unittest-state.cpp
+++ b/zera-json-params/unittest/unittest-state.cpp
@@ -16,8 +16,7 @@ TEST(TEST_STATE,VALID_DEFAULT) {
     ZeraJsonParamsStructure jsonParamStructure;
     jsonParamStructure.setJson(ZeraJsonHelper::loadFromQrc("TEST_STATE,VALID_ALL_TYPES"));
 
-    ZeraJsonParamsState jsonParamState;
-    jsonParamState.setStructure(jsonParamStructure.getJson());
+    ZeraJsonParamsState jsonParamState(jsonParamStructure.getJson());
     QJsonObject jsonParamDefault = jsonParamState.getDefaultJsonState();
     QJsonObject jsonParamDefaultExpected = ZeraJsonHelper::loadFromQrc("TEST_STATE,VALID_ALL_TYPES_DEFAULT");
     EXPECT_EQ(jsonParamDefault, jsonParamDefaultExpected) << "Expected default params do not match";
@@ -26,7 +25,8 @@ TEST(TEST_STATE,VALID_DEFAULT) {
 TEST(TEST_STATE,EMPTY_STRUCT) {
     QJsonObject jsonParamDummy;
     jsonParamDummy.insert("dummy", true);
-    ZeraJsonParamsState jsonParamState;
+    QJsonObject emptyStruct;
+    ZeraJsonParamsState jsonParamState(emptyStruct);
     ZeraJsonParamsState::ErrList errList = jsonParamState.validateJsonState(jsonParamDummy);
     ASSERT_EQ(errList.count(), 1);
     EXPECT_EQ(errList[0].m_errType,ZeraJsonParamsState::errorTypes::ERR_INVALID_STRUCTURE);
@@ -40,15 +40,15 @@ TEST(TEST_STATE,EMPTY_STATE) {
     ASSERT_TRUE(errListStructure.isEmpty());
 
     // Valiate empty state & expect empty state errror
-    ZeraJsonParamsState jsonParamState;
-    jsonParamState.setStructure(jsonParamStructure.getJson());
+    ZeraJsonParamsState jsonParamState(jsonParamStructure.getJson());
     ZeraJsonParamsState::ErrList errList = jsonParamState.validateJsonState(QJsonObject());
     ASSERT_EQ(errList.count(), 1);
     EXPECT_EQ(errList[0].m_errType,ZeraJsonParamsState::errorTypes::ERR_EMPTY_STATE);
 }
 
 TEST(TEST_STATE,EMPTY_STATE_AND_STRUCT) {
-    ZeraJsonParamsState jsonParamState;
+    QJsonObject emptyStruct;
+    ZeraJsonParamsState jsonParamState(emptyStruct);
     ZeraJsonParamsState::ErrList errList = jsonParamState.validateJsonState(QJsonObject());
     EXPECT_EQ(errList.count(), 2);
 }
@@ -59,8 +59,7 @@ TEST(TEST_STATE,VALIDATE_DEFAULT) {
     ZeraJsonParamsStructure::ErrList errListStructure = jsonParamStructure.setJson(jsonStructureRaw);
     ASSERT_TRUE(errListStructure.isEmpty());
 
-    ZeraJsonParamsState jsonParamState;
-    jsonParamState.setStructure(jsonParamStructure.getJson());
+    ZeraJsonParamsState jsonParamState(jsonParamStructure.getJson());
 
     QJsonObject jsonParamDefault = jsonParamState.getDefaultJsonState();
     ZeraJsonParamsState::ErrList paramErrList = jsonParamState.validateJsonState(jsonParamDefault);
@@ -73,8 +72,7 @@ TEST(TEST_STATE,VALIDATE_DEFAULT_ONE_MISSING) {
     ZeraJsonParamsStructure::ErrList errListStructure = jsonParamStructure.setJson(jsonStructureRaw);
     ASSERT_TRUE(errListStructure.isEmpty());
 
-    ZeraJsonParamsState jsonParamState;
-    jsonParamState.setStructure(jsonParamStructure.getJson());
+    ZeraJsonParamsState jsonParamState(jsonParamStructure.getJson());
 
     QJsonObject stateDefault = jsonParamState.getDefaultJsonState();
     QJsonObject stateOneMissing = stateDefault;
@@ -90,8 +88,7 @@ TEST(TEST_STATE,VALIDATE_TYPE_ERRORS) {
     ZeraJsonParamsStructure::ErrList errListStructure = jsonParamStructure.setJson(jsonStructureRaw);
     ASSERT_TRUE(errListStructure.isEmpty());
 
-    ZeraJsonParamsState jsonParamState;
-    jsonParamState.setStructure(jsonParamStructure.getJson());
+    ZeraJsonParamsState jsonParamState(jsonParamStructure.getJson());
 
     QJsonObject jsonStateWrongTypes = ZeraJsonHelper::loadFromQrc("TEST_STATE,VALIDATE_TYPE_ERRORS");
     ZeraJsonParamsState::ErrList paramErrList = jsonParamState.validateJsonState(jsonStateWrongTypes);
@@ -104,8 +101,7 @@ TEST(TEST_STATE,VALIDATE_LIMIT_ERRORS) {
     ZeraJsonParamsStructure::ErrList errListStructure = jsonParamStructure.setJson(jsonStructureRaw);
     ASSERT_TRUE(errListStructure.isEmpty());
 
-    ZeraJsonParamsState jsonParamState;
-    jsonParamState.setStructure(jsonParamStructure.getJson());
+    ZeraJsonParamsState jsonParamState(jsonParamStructure.getJson());
 
     QJsonObject jsonStateWrongTypes = ZeraJsonHelper::loadFromQrc("TEST_STATE,VALIDATE_LIMIT_ERRORS");
     ZeraJsonParamsState::ErrList paramErrList = jsonParamState.validateJsonState(jsonStateWrongTypes);
@@ -118,8 +114,7 @@ TEST(TEST_STATE,CHECK_COMLETE_EMPTY) {
     ZeraJsonParamsStructure::ErrList errListStructure = jsonParamStructure.setJson(jsonStructureRaw);
     ASSERT_TRUE(errListStructure.isEmpty());
 
-    ZeraJsonParamsState jsonParamState;
-    jsonParamState.setStructure(jsonParamStructure.getJson());
+    ZeraJsonParamsState jsonParamState(jsonParamStructure.getJson());
 
     QJsonObject emptyState;
     EXPECT_FALSE(jsonParamState.isJsonStateComplete(emptyState));
@@ -131,8 +126,7 @@ TEST(TEST_STATE,CHECK_COMLETE_OK) {
     ZeraJsonParamsStructure::ErrList errListStructure = jsonParamStructure.setJson(jsonStructureRaw);
     ASSERT_TRUE(errListStructure.isEmpty());
 
-    ZeraJsonParamsState jsonParamState;
-    jsonParamState.setStructure(jsonParamStructure.getJson());
+    ZeraJsonParamsState jsonParamState(jsonParamStructure.getJson());
 
     QJsonObject stateDefault = jsonParamState.getDefaultJsonState();
     EXPECT_TRUE(jsonParamState.isJsonStateComplete(stateDefault));


### PR DESCRIPTION
* We get more compact code most situations
* Leave default constructor & setStructure
  * to keep API compatible
  * for situations where structure is not yet available at the time of creation
    of ZeraJsonParamsState object

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>